### PR TITLE
pass collection object to derivative hook

### DIFF
--- a/islandora_batch_derivative_trigger.drush.inc
+++ b/islandora_batch_derivative_trigger.drush.inc
@@ -143,7 +143,7 @@ function drush_islandora_batch_derivative_trigger_regenerate_derivatives() {
   if (!is_array($dsids) && is_array($batch_info['content_models'])) {
     $dsids = array();
     foreach ($batch_info['content_models'] as $content_model) {
-      $dsids += array_keys(islandora_batch_derivative_trigger_regenerate_derivatives_form_get_derivatives_list($content_model, array()));
+      $dsids += array_keys(islandora_batch_derivative_trigger_regenerate_derivatives_form_get_derivatives_list($content_model, array($batch_info['collection'])));
     }
     $dsids = array_unique($dsids);
   }

--- a/islandora_batch_derivative_trigger.module
+++ b/islandora_batch_derivative_trigger.module
@@ -76,7 +76,7 @@ function islandora_batch_derivative_trigger_regenerate_derivatives_form(array $f
         '#header' => array(
           'dsid' => t('DSID'),
         ),
-        '#options' => islandora_batch_derivative_trigger_regenerate_derivatives_form_get_derivatives_list($content_model, array()),
+        '#options' => islandora_batch_derivative_trigger_regenerate_derivatives_form_get_derivatives_list($content_model, array($collection)),
         '#empty' => t('No derivative DSIDs for the selected content model.'),
       ),
       'children' => islandora_batch_derivative_trigger_get_children_select_table_form_element_with_content_model($collection, array(


### PR DESCRIPTION
fix for 

Recoverable fatal error: Argument 1 passed to islandora_compound_object_islandora_derivative() must be an instance of AbstractObject, none given in islandora_compound_object_islandora_derivative() (line 292 of /usr/local/fedora/drupal/sites/all/modules/islandora_solution_pack_compound/islandora_compound_object.module).