### PR TITLE
select $source using $mapping instead of $xslt_id, which may fail in some odd cases

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -415,7 +415,7 @@ function islandora_batch_derivative_trigger_regenerate_dc_metadata(AbstractObjec
       ->fetchField();
     $source = db_select('xml_form_builder_default_xslts', 'xd')
       ->fields('xd', array('dsid'))
-      ->condition('xslt_id', $xslt_id, '=')
+      ->condition('id', $mapping, '=')
       ->execute()
       ->fetchField();
     $xslt = new DOMDocument();


### PR DESCRIPTION
 If for some reason we have the same xslt assigned to mappings with different dsid values (unlikely, but not impossible) then we may get the wrong source dsid returned. Since we already know the mapping id we might as well use that directly to look up the dsid.